### PR TITLE
Add ability to handle explicit schema name.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ env:
     - TOXENV=test
     - TOXENV=install
     - TOXENV=flasksqlalchemy
+services:
+    - postgresql
 before_install:
     - sudo apt-get -qq install graphviz > /dev/null
     - travis_retry pip install tox flake8

--- a/eralchemy/models.py
+++ b/eralchemy/models.py
@@ -15,11 +15,11 @@ class Drawable:
 
     def to_markdown(self):
         """Transforms the intermediary object to it's syntax in the er markup. """
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def to_dot(self):
         """Transforms the intermediary object to it's syntax in the dot format. """
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
@@ -27,7 +27,7 @@ class Drawable:
     @staticmethod
     def make_from_match(self):
         """ Used in the parsing of files. Transforms a regex match to a Drawable object. """
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def __str__(self):
         return self.to_markdown()
@@ -35,7 +35,7 @@ class Drawable:
 
 class Column(Drawable):
     """ Represents a Column in the intermediaty syntax """
-    RE = re.compile('(?P<primary>\*?)(?P<name>[^\s]+)\s*(\{label:\s*"(?P<label>[^"]+)"\})?')
+    RE = re.compile(r'(?P<primary>\*?)(?P<name>[^\s]+)\s*(\{label:\s*"(?P<label>[^"]+)"\})?')
 
     @staticmethod
     def make_from_match(match):
@@ -76,7 +76,7 @@ class Column(Drawable):
 class Relation(Drawable):
     """ Represents a Relation in the intermediaty syntax """
     RE = re.compile(
-        '(?P<left_name>[^\s]+)\s*(?P<left_cardinality>[*?+1])--(?P<right_cardinality>[*?+1])\s*(?P<right_name>[^\s]+)')  # noqa: E501
+        r'(?P<left_name>[^\s]+)\s*(?P<left_cardinality>[*?+1])--(?P<right_cardinality>[*?+1])\s*(?P<right_name>[^\s]+)')  # noqa: E501
     cardinalities = {
         '*': '0..N',
         '?': '{0,1}',
@@ -142,7 +142,7 @@ class Relation(Drawable):
 
 class Table(Drawable):
     """ Represents a Table in the intermediaty syntax """
-    RE = re.compile('\[(?P<name>[^]]+)\]')
+    RE = re.compile(r'\[(?P<name>[^]]+)\]')
 
     def __init__(self, name, columns):
         self.name = name

--- a/eralchemy/sqla.py
+++ b/eralchemy/sqla.py
@@ -13,9 +13,20 @@ if sys.version_info[0] == 3:
 
 def relation_to_intermediary(fk):
     """Transform an SQLAlchemy ForeignKey object to it's intermediary representation. """
+
+    # In the cases where schema name is provided, _column_tokens[1] is
+    # insufficient to correctly identify the relationship. Therefore, assuming
+    # that the schema name is _column_tokens[0], when set seems the least
+    # intrusive approach. The other one would be sending in the schema name
+    # as another parameter into this function from metadata_to_intermediary()
+    left_column = format_name(fk._column_tokens[1])
+    if fk._column_tokens[0]:
+        left_column = "{}.{}".format(format_name(fk._column_tokens[0]),
+                                     format_name(fk._column_tokens[1]))
+
     return Relation(
-        right_col=format_name(fk.parent.table.fullname),
-        left_col=format_name(fk._column_tokens[1]),
+        right_col=sqla.format_name(fk.parent.table.fullname),
+        left_col=left_column,
         right_cardinality='?',
         left_cardinality='*',
     )

--- a/eralchemy/sqla.py
+++ b/eralchemy/sqla.py
@@ -11,22 +11,28 @@ if sys.version_info[0] == 3:
     unicode = str
 
 
-def relation_to_intermediary(fk):
+def get_relationship_left_column(fk, schema):
+    """Return the proper 'parent' name of the relationship described with the
+    specified `fk` and `schema`. The 'parent' is the entity stored in the left
+    column of the Relation object.
+    """
+    if schema:
+        return "{}.{}".format(schema, format_name(fk._column_tokens[1]))
+
+    return format_name(fk._column_tokens[1])
+
+
+def relation_to_intermediary(fk, schema=None):
     """Transform an SQLAlchemy ForeignKey object to it's intermediary representation. """
 
     # In the cases where schema name is provided, _column_tokens[1] is
-    # insufficient to correctly identify the relationship. Therefore, assuming
-    # that the schema name is _column_tokens[0], when set seems the least
-    # intrusive approach. The other one would be sending in the schema name
-    # as another parameter into this function from metadata_to_intermediary()
-    left_column = format_name(fk._column_tokens[1])
-    if fk._column_tokens[0]:
-        left_column = "{}.{}".format(format_name(fk._column_tokens[0]),
-                                     format_name(fk._column_tokens[1]))
+    # insufficient to correctly identify the relationship. Therefore, we use
+    # the schema name provided in the invocation of the script to prefix the
+    # retrieved table names.
 
     return Relation(
         right_col=format_name(fk.parent.table.fullname),
-        left_col=left_column,
+        left_col=get_relationship_left_column(fk, schema),
         right_cardinality='?',
         left_cardinality='*',
     )
@@ -65,7 +71,9 @@ def table_to_intermediary(table):
 def metadata_to_intermediary(metadata):
     """ Transforms SQLAlchemy metadata to the intermediary representation. """
     tables = [table_to_intermediary(table) for table in metadata.tables.values()]
-    relationships = [relation_to_intermediary(fk) for table in metadata.tables.values() for fk in table.foreign_keys]
+    relationships = [relation_to_intermediary(fk, metadata.schema)
+                     for table in metadata.tables.values()
+                     for fk in table.foreign_keys]
     return tables, relationships
 
 

--- a/eralchemy/sqla.py
+++ b/eralchemy/sqla.py
@@ -25,7 +25,7 @@ def relation_to_intermediary(fk):
                                      format_name(fk._column_tokens[1]))
 
     return Relation(
-        right_col=sqla.format_name(fk.parent.table.fullname),
+        right_col=format_name(fk.parent.table.fullname),
         left_col=left_column,
         right_cardinality='?',
         left_cardinality='*',

--- a/tests/test_intermediary_to_er.py
+++ b/tests/test_intermediary_to_er.py
@@ -4,7 +4,7 @@ from eralchemy.main import _intermediary_to_markdown
 
 import re
 
-column_re = re.compile('(?P<key>\*?)(?P<name>[^*].+) \{label:\"(?P<type>.+)\"\}')
+column_re = re.compile(r'(?P<key>\*?)(?P<name>[^*].+) \{label:\"(?P<type>.+)\"\}')
 
 
 def test_all_to_er():

--- a/tests/test_sqla_to_intermediary.py
+++ b/tests/test_sqla_to_intermediary.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import re
+
 from eralchemy.sqla import column_to_intermediary, declarative_to_intermediary, database_to_intermediary, \
     table_to_intermediary
 from tests.common import parent_id, parent_name, child_id, child_parent_id, Parent, Child, Base, \
@@ -75,9 +77,46 @@ def test_database_to_intermediary_with_schema():
     # Not in because different schema.
     assert relation not in relationships
     assert exclude_relation not in relationships
+
+
+def test_table_names_in_relationships():
+    db_uri = create_db()
+    tables, relationships = database_to_intermediary(db_uri)
+    table_names = [t.name for t in tables]
+
+    # Assert column names are table names
+    assert all(r.right_col in table_names for r in relationships)
+    assert all(r.left_col in table_names for r in relationships)
+
+    # Assert column names match table names
+    for r in relationships:
+        r_name = table_names[table_names.index(r.right_col)]
+        l_name = table_names[table_names.index(r.left_col)]
+
+        # Table name in relationship should *NOT* have a schema
+        assert(r_name.find('.') == -1)
+        assert(l_name.find('.') == -1)
+
+
+def test_table_names_in_relationships_with_schema():
+    db_uri = create_db()
+    schema_name = 'test'
+    matcher = re.compile("{}\.[\S+]".format(schema_name), re.I)
+    tables, relationships = database_to_intermediary(db_uri, schema=schema_name)
+    table_names = [t.name for t in tables]
+
     # Assert column names match table names, including schema
     assert all(r.right_col in table_names for r in relationships)
     assert all(r.left_col in table_names for r in relationships)
+
+    # Assert column names match table names, including schema
+    for r in relationships:
+        r_name = table_names[table_names.index(r.right_col)]
+        l_name = table_names[table_names.index(r.left_col)]
+
+        # Table name in relationship *SHOULD* have a schema
+        assert(re.match(matcher, r_name) is not None)
+        assert(re.match(matcher, l_name) is not None)
 
 
 def test_flask_sqlalchemy():

--- a/tests/test_sqla_to_intermediary.py
+++ b/tests/test_sqla_to_intermediary.py
@@ -66,6 +66,7 @@ def test_database_to_intermediary():
 def test_database_to_intermediary_with_schema():
     db_uri = create_db()
     tables, relationships = database_to_intermediary(db_uri, schema='test')
+    table_names = [t.name for t in tables]
 
     assert len(tables) == 3
     assert len(relationships) == 2
@@ -74,6 +75,9 @@ def test_database_to_intermediary_with_schema():
     # Not in because different schema.
     assert relation not in relationships
     assert exclude_relation not in relationships
+    # Assert column names match table names, including schema
+    assert all(r.right_col in table_names for r in relationships)
+    assert all(r.left_col in table_names for r in relationships)
 
 
 def test_flask_sqlalchemy():

--- a/tests/test_sqla_to_intermediary.py
+++ b/tests/test_sqla_to_intermediary.py
@@ -68,7 +68,6 @@ def test_database_to_intermediary():
 def test_database_to_intermediary_with_schema():
     db_uri = create_db()
     tables, relationships = database_to_intermediary(db_uri, schema='test')
-    table_names = [t.name for t in tables]
 
     assert len(tables) == 3
     assert len(relationships) == 2
@@ -101,7 +100,7 @@ def test_table_names_in_relationships():
 def test_table_names_in_relationships_with_schema():
     db_uri = create_db()
     schema_name = 'test'
-    matcher = re.compile("{}\.[\S+]".format(schema_name), re.I)
+    matcher = re.compile(r"{}\.[\S+]".format(schema_name), re.I)
     tables, relationships = database_to_intermediary(db_uri, schema=schema_name)
     table_names = [t.name for t in tables]
 


### PR DESCRIPTION
When invoking `render_er` with a schema name, like:

```python
    render_er(f"postgresql+psycopg2://DB_USERNAME@localhost:5001/DB_NAME",
              "DB_NAME.png",
              mode='graph',
              schema='DB_NAME')
```

The resulting image is missing the proper relationships. As mentioned in issue #67, the problem is that the `left_col` argument to `Relation` is missing the name of the schema. This PR aims to address the problem using the [subjectively] least intrusive means.

Closes #67 
