### PR TITLE
[tests] - Use testing.postgresql to streamline database tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ env:
 before_install:
     - sudo apt-get -qq install graphviz > /dev/null
     - travis_retry pip install tox flake8
-    - psql -U postgres -c "CREATE DATABASE test ENCODING 'UTF8';"
-    - psql -U postgres test -c "CREATE SCHEMA test;"
 install: true
 script:
     - flake8 .

--- a/readme.md
+++ b/readme.md
@@ -70,9 +70,7 @@ Thanks to it's modular architecture, it can be connected to other ORMs/ODMs/OGMs
 
 Every feedback is welcome on the [GitHub issues](https://github.com/Alexis-benoist/eralchemy/issues).
 
-To run the tests, use : `$ py.test`.
-Some tests require a local postgres database with a schema named test in a database
-named test all owned by a user named postgres with a password of postgres.
+To run the tests, ensure that you have tox, postgres, and graphviz installed, and run `$ tox`.
 
 All tested PR are welcome.
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -14,3 +14,5 @@ tox==2.3.1
 virtualenv==15.0.2
 Werkzeug==0.11.10
 wheel==0.29.0
+testing.postgresql==1.3.0
+testing.common.database==2.0.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+from tests.common import postgresql_db, sqlite_db
+
+# Define __all__ to make flake8 happy.
+__all__ = [
+    "postgresql_db",
+    "sqlite_db",
+]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from eralchemy.main import all_to_intermediary, get_output_mode, intermediary_to_schema, \
     intermediary_to_dot, intermediary_to_markdown, filter_resources
-from tests.common import Base, check_tables_relationships, check_intermediary_representation_simple_table, create_db, \
+from tests.common import Base, check_tables_relationships, check_intermediary_representation_simple_table, \
     markdown, relationships, tables, check_intermediary_representation_simple_all_table, check_tables_columns, \
     check_filter
 
@@ -13,15 +13,13 @@ def test_all_to_intermediary_base():
     check_intermediary_representation_simple_all_table(tables, relationships)
 
 
-def test_all_to_intermediary_db_sqlite():
-    db_uri = create_db(db_uri="sqlite:///test.db", use_sqlite=True)
-    tables, relationships = all_to_intermediary(db_uri)
+def test_all_to_intermediary_db_sqlite(sqlite_db):
+    tables, relationships = all_to_intermediary(sqlite_db)
     check_intermediary_representation_simple_table(tables, relationships)
 
 
-def test_all_to_intermediary_db():
-    db_uri = create_db()
-    tables, relationships = all_to_intermediary(db_uri)
+def test_all_to_intermediary_db(postgresql_db):
+    tables, relationships = all_to_intermediary(postgresql_db)
     check_intermediary_representation_simple_table(tables, relationships)
 
 

--- a/tests/test_sqla_to_intermediary.py
+++ b/tests/test_sqla_to_intermediary.py
@@ -5,7 +5,7 @@ from eralchemy.sqla import column_to_intermediary, declarative_to_intermediary, 
 from tests.common import parent_id, parent_name, child_id, child_parent_id, Parent, Child, Base, \
     child, parent, Relation, Table, relation, exclude_relation, \
     check_intermediary_representation_simple_all_table
-from tests.common import check_intermediary_representation_simple_table, create_db
+from tests.common import check_intermediary_representation_simple_table
 
 
 def check_column(column, column_intermediary):
@@ -57,15 +57,14 @@ def test_tables():
     table_equals_helper(Parent, parent)
 
 
-def test_database_to_intermediary():
-    db_uri = create_db()
-    tables, relationships = database_to_intermediary(db_uri)
+def test_database_to_intermediary(postgresql_db):
+    tables, relationships = database_to_intermediary(postgresql_db)
     check_intermediary_representation_simple_table(tables, relationships)
 
 
-def test_database_to_intermediary_with_schema():
-    db_uri = create_db()
-    tables, relationships = database_to_intermediary(db_uri, schema='test')
+def test_database_to_intermediary_with_schema(postgresql_db):
+
+    tables, relationships = database_to_intermediary(postgresql_db, schema='test')
 
     assert len(tables) == 3
     assert len(relationships) == 2


### PR DESCRIPTION
By using testing.postgresql, users no longer need to have a running
PostgreSQL database already created prior to running the tests.