### PR TITLE
Draw column relations

### DIFF
--- a/eralchemy/main.py
+++ b/eralchemy/main.py
@@ -309,10 +309,10 @@ def filter_resources(
     _relationships = [
         r
         for r in _relationships
-        if not exclude_tables_re.fullmatch(r.right_col)
-        and not exclude_tables_re.fullmatch(r.left_col)
-        and include_tables_re.fullmatch(r.right_col)
-        and include_tables_re.fullmatch(r.left_col)
+        if not exclude_tables_re.fullmatch(r.right_table)
+        and not exclude_tables_re.fullmatch(r.left_table)
+        and include_tables_re.fullmatch(r.right_table)
+        and include_tables_re.fullmatch(r.left_table)
     ]
 
     def check_column(name):

--- a/eralchemy/parser.py
+++ b/eralchemy/parser.py
@@ -124,8 +124,8 @@ def update_models(
 
     if isinstance(new_obj, Relation):
         tables_names = [t.name for t in tables]
-        _check_colname_in_lst(new_obj.right_col, tables_names)
-        _check_colname_in_lst(new_obj.left_col, tables_names)
+        _check_colname_in_lst(new_obj.right_table, tables_names)
+        _check_colname_in_lst(new_obj.left_table, tables_names)
         return current_table, tables, relations + [new_obj]
 
     if isinstance(new_obj, Column):

--- a/eralchemy/sqla.py
+++ b/eralchemy/sqla.py
@@ -47,8 +47,10 @@ def relation_to_intermediary(fk: sa.ForeignKey) -> Relation:
         # if this is the case, we are not optional and must be unique
         right_cardinality = "1" if check_all_compound_same_parent(fk) else "*"
     return Relation(
-        right_col=format_name(fk.parent.table.fullname),
-        left_col=format_name(fk.column.table.fullname),
+        right_table=format_name(fk.parent.table.fullname),
+        right_column=format_name(fk.parent.name),
+        left_table=format_name(fk.column.table.fullname),
+        left_column=format_name(fk.column.name),
         right_cardinality=right_cardinality,
         left_cardinality="?" if fk.parent.nullable else "1",
     )

--- a/tests/common.py
+++ b/tests/common.py
@@ -68,10 +68,12 @@ child_parent_id = ERColumn(
 )
 
 relation = Relation(
-    right_col="parent",
-    left_col="child",
-    right_cardinality="?",
+    left_table="child",
+    left_column="parent_id",
+    right_table="parent",
+    right_column="id",
     left_cardinality="*",
+    right_cardinality="?",
 )
 
 exclude_id = ERColumn(name="id", type="INTEGER", is_key=True)
@@ -82,8 +84,10 @@ exclude_parent_id = ERColumn(
 )
 
 exclude_relation = Relation(
-    right_col="parent",
-    left_col="exclude",
+    right_table="parent",
+    right_column="id",
+    left_table="exclude",
+    left_column="parent_id",
     right_cardinality="?",
     left_cardinality="*",
 )
@@ -117,8 +121,8 @@ markdown = """
     [exclude]
         *id {label:"INTEGER"}
         parent_id {label:"INTEGER"}
-    parent ?--* child
-    parent ?--* exclude
+    child."parent_id" *--? parent."id"
+    exclude."parent_id" *--? parent."id"
     """
 
 

--- a/tests/test_intermediary_to_er.py
+++ b/tests/test_intermediary_to_er.py
@@ -38,7 +38,10 @@ def test_column_to_er():
 
 
 def test_relation():
-    assert relation.to_markdown() in ["parent ?--* child", "child *--? parent"]
+    assert relation.to_markdown() in [
+        'parent."id" *--? child."parent_id"',
+        'child."parent_id" *--? parent."id"',
+    ]
 
 
 def assert_table_well_rendered_to_er(table):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -73,9 +73,11 @@ def test_parse_line():
         assert isinstance(rv, Column)
 
     for s in relations_lst:
-        rv = parse_line(s)
-        assert rv.right_col == s[16:].strip()
-        assert rv.left_col == s[:12].strip()
+        rv = parse_line(s)  # type: Relation
+        assert rv.right_table == s[16:].strip()
+        assert rv.right_column == ""
+        assert rv.left_table == s[:12].strip()
+        assert rv.left_column == ""
         assert rv.right_cardinality == s[15]
         assert rv.left_cardinality == s[12]
         assert isinstance(rv, Relation)

--- a/tests/test_sqla_to_intermediary.py
+++ b/tests/test_sqla_to_intermediary.py
@@ -115,24 +115,26 @@ def test_flask_sqlalchemy():
     check_intermediary_representation_simple_all_table(tables, relationships)
 
 
+@pytest.mark.external_db
 def test_table_names_in_relationships(pg_db_uri):
     tables, relationships = database_to_intermediary(pg_db_uri)
     table_names = [t.name for t in tables]
 
     # Assert column names are table names
-    assert all(r.right_col in table_names for r in relationships)
-    assert all(r.left_col in table_names for r in relationships)
+    assert all(r.right_table in table_names for r in relationships)
+    assert all(r.left_table in table_names for r in relationships)
 
     # Assert column names match table names
     for r in relationships:
-        r_name = table_names[table_names.index(r.right_col)]
-        l_name = table_names[table_names.index(r.left_col)]
+        r_name = table_names[table_names.index(r.right_table)]
+        l_name = table_names[table_names.index(r.left_table)]
 
         # Table name in relationship should *NOT* have a schema
         assert r_name.find(".") == -1
         assert l_name.find(".") == -1
 
 
+@pytest.mark.external_db
 def test_table_names_in_relationships_with_schema(pg_db_uri):
     schema_name = "test"
     matcher = re.compile(rf"{schema_name}\.[\S+]", re.I)
@@ -140,8 +142,8 @@ def test_table_names_in_relationships_with_schema(pg_db_uri):
     table_names = [t.name for t in tables]
 
     # Assert column names match table names, including schema
-    assert all(r.right_col in table_names for r in relationships)
-    assert all(r.left_col in table_names for r in relationships)
+    assert all(r.right_table in table_names for r in relationships)
+    assert all(r.left_table in table_names for r in relationships)
 
     # Assert column names match table names, including schema
     for r in relationships:


### PR DESCRIPTION
This PR takes advantage of Graphviz support for the PORT attribute on HTML-like labels, to draw the relationships between the specific columns in tables, as opposed to arbitrarily linking the tables together. See https://www.graphviz.org/doc/info/shapes.html#html for more information.

This PR addresses issue https://github.com/Alexis-benoist/eralchemy/issues/55. It includes the initial work to support this feature, done by @sersorrel. I then added support for this feature in the Markdown output and updated the existing tests.

Below is an example of the what the newsmeme ER diagram looks like with these changes.

![newsmeme-1](https://user-images.githubusercontent.com/26766626/82743638-15596480-9d3c-11ea-884c-58c772c4aea7.png)


