### PR TITLE
Allow having either graphviz or pygraphviz installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ To install eralchemy, just do:
 
     $ pip install eralchemy
 
+### Graph library flavors
+
+To create Pictures and PDFs, eralchemy relies on either graphviz or pygraphviz.
+
+You can use either
+
+    $ pip install eralchemy[graphviz]
+
+or
+
+    $ pip install eralchemy[pygraphviz]
+
+to retrieve the correct dependencies.
+The `graphviz` library is the default if both are installed.
+
 `eralchemy` requires [GraphViz](http://www.graphviz.org/download) to generate the graphs and Python. Both are available for Windows, Mac and Linux.
 
 For Debian based systems, run:

--- a/eralchemy/main.py
+++ b/eralchemy/main.py
@@ -5,7 +5,8 @@ import re
 import sys
 from importlib.metadata import PackageNotFoundError, version
 
-from pygraphviz.agraph import AGraph
+#from pygraphviz.agraph import AGraph
+from graphviz import Source
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.exc import ArgumentError
 
@@ -139,10 +140,12 @@ def intermediary_to_dot(tables, relationships, output, title=""):
 def intermediary_to_schema(tables, relationships, output, title=""):
     """Transforms and save the intermediary representation to the file chosen."""
     dot_file = _intermediary_to_dot(tables, relationships, title)
-    graph = AGraph()
-    graph = graph.from_string(dot_file)
-    extension = output.split(".")[-1]
-    graph.draw(path=output, prog="dot", format=extension)
+    #graph = AGraph()
+    #graph = graph.from_string(dot_file)
+    extension = output.split('.')[-1]
+    #graph.draw(path=output, prog='dot', format=extension)
+    #Source.from_file(filename, engine='dot', format=extension)
+    return Source(dot_file, engine='dot', format=extension)
 
 
 def _intermediary_to_markdown(tables, relationships):
@@ -363,16 +366,13 @@ def render_er(
     """
     try:
         tables, relationships = all_to_intermediary(input, schema=schema)
-        tables, relationships = filter_resources(
-            tables,
-            relationships,
-            include_tables=include_tables,
-            include_columns=include_columns,
-            exclude_tables=exclude_tables,
-            exclude_columns=exclude_columns,
-        )
+        if include is not None:
+            tables, relationships = filter_includes(tables, relationships, include)
+        if exclude is not None:
+            tables, relationships = filter_excludes(tables, relationships, exclude)
         intermediary_to_output = get_output_mode(output, mode)
-        intermediary_to_output(tables, relationships, output, title)
+        out = intermediary_to_output(tables, relationships, output)
+        return out
     except ImportError as e:
         module_name = e.message.split()[-1]
         print(f'Please install {module_name} using "pip install {module_name}".')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,7 @@ classifiers=[
 ]
 requires-python = ">=3.8"
 dependencies = [
-  "sqlalchemy >= 1.4",
-  "pygraphviz >= 1.9",
+  "sqlalchemy >= 1.4"
 ]
 
 [project.urls]
@@ -35,10 +34,14 @@ homepage = "https://github.com/eralchemy/eralchemy"
 repository = "https://github.com/eralchemy/eralchemy"
 
 [project.optional-dependencies]
+graphviz = ["graphviz >= 0.20.3"]
+pygraphviz = ["pygraphviz >= 1.9"]
 ci = [
   "flask-sqlalchemy >= 2.5.1",
   "psycopg2 >= 2.9.3",
   "pytest >= 7.4.3",
+  "pygraphviz >= 1.9",
+  "graphviz >= 0.20.3",
 ]
 dev = [
   "nox",
@@ -103,7 +106,7 @@ show_error_codes = true
 pretty = true
 
 [[tool.mypy.overrides]]
-module = ["pygraphviz.*", "sqlalchemy.*"]
+module = ["graphviz.*", "pygraphviz.*", "sqlalchemy.*"]
 ignore_missing_imports = true
 
 

--- a/tests/test_intermediary_to_dot.py
+++ b/tests/test_intermediary_to_dot.py
@@ -30,7 +30,7 @@ column_inside = re.compile(
     "(?P<key_closing>.*)\\ <FONT\\>\\ \\[(?P<type>.*)\\]\\<\\/FONT\\>",
 )
 
-
+#This test needs fixing with move to graphviz
 def assert_is_dot_format(dot):
     """Checks that the dot is usable by graphviz."""
 

--- a/tests/test_intermediary_to_dot.py
+++ b/tests/test_intermediary_to_dot.py
@@ -30,7 +30,8 @@ column_inside = re.compile(
     "(?P<key_closing>.*)\\ <FONT\\>\\ \\[(?P<type>.*)\\]\\<\\/FONT\\>",
 )
 
-#This test needs fixing with move to graphviz
+
+# This test needs fixing with move to graphviz
 def assert_is_dot_format(dot):
     """Checks that the dot is usable by graphviz."""
 

--- a/tests/test_sqla_to_intermediary.py
+++ b/tests/test_sqla_to_intermediary.py
@@ -115,6 +115,7 @@ def test_flask_sqlalchemy():
     check_intermediary_representation_simple_all_table(tables, relationships)
 
 
+@pytest.mark.external_db
 def test_table_names_in_relationships(pg_db_uri):
     tables, relationships = database_to_intermediary(pg_db_uri)
     table_names = [t.name for t in tables]
@@ -133,6 +134,7 @@ def test_table_names_in_relationships(pg_db_uri):
         assert l_name.find(".") == -1
 
 
+@pytest.mark.external_db
 def test_table_names_in_relationships_with_schema(pg_db_uri):
     schema_name = "test"
     matcher = re.compile(rf"{schema_name}\.[\S+]", re.I)


### PR DESCRIPTION
allow people to have either pygraphviz or graphviz installed

Remove graphviz from the required dependencies, as it is not needed when using the mermaid/markdown export

---

We could extract this to a `graphing.py` which contains the library handling so that it does not adds to main further.

fixes #121 