### PR TITLE
fix pipeline to have running tests

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,6 +5,12 @@
 
 name: CI Tests
 
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+*.orig

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,12 +14,19 @@ repos:
         additional_dependencies:
           - tomli
 
+  - repo: "https://github.com/pre-commit/mirrors-prettier"
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        stages: [commit]
+        exclude: tests\/test_.+\.
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.4.4
     hooks:
       # Run the linter.
       - id: ruff
-        args: [ --fix ]
+        args: [--fix]
       # Run the formatter.
       - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,10 @@
 repos:
-  - repo: "https://github.com/psf/black"
-    rev: "22.3.0"
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
     hooks:
-      - id: black
-        stages: [commit]
-
-  - repo: "https://github.com/pre-commit/mirrors-prettier"
-    rev: "v2.7.1"
-    hooks:
-      - id: prettier
-        stages: [commit]
-        exclude: tests\/test_.+\.
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
@@ -20,8 +14,12 @@ repos:
         additional_dependencies:
           - tomli
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.215"
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.4.4
     hooks:
+      # Run the linter.
       - id: ruff
-        stages: [commit]
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,17 +110,9 @@ ignore_missing_imports = true
 [tool.ruff]
 ignore-init-module-imports = true
 fix = true
-select = ["E", "F", "W", "I", "D", "RUF"]
+select = ["E", "F", "W", "I", "UP", "G"]
 ignore = [
-  "D100",  # Missing docstring in public module
-  "D101",  # Missing docstring in public class
-  "D102",  # Missing docstring in public method
-  "D103",  # Missing docstring in public function
-  "D104",  # Missing docstring in public package
-  "D105",  # Missing docstring in magic method
-  "D107",  # Missing docstring in `__init__`
-  "E501",  # line too long | Black take care of it
-
+  "E501",  # line too long
 ]
 
 [tool.ruff.flake8-quotes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,12 +114,10 @@ select = ["E", "F", "W", "I", "UP", "G"]
 ignore = [
   "E501",  # line too long
 ]
+line-length = 100
 
 [tool.ruff.flake8-quotes]
 docstring-quotes = "double"
 
 [tool.ruff.pydocstyle]
 convention = "google"
-
-[tool.black]
-line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,8 +110,15 @@ ignore_missing_imports = true
 [tool.ruff]
 ignore-init-module-imports = true
 fix = true
-select = ["E", "F", "W", "I", "UP", "G"]
+select = ["D", "E", "F", "W", "I", "UP", "G"]
 ignore = [
+  "D100",  # Missing docstring in public module
+  "D101",  # Missing docstring in public class
+  "D102",  # Missing docstring in public method
+  "D103",  # Missing docstring in public function
+  "D104",  # Missing docstring in public package
+  "D105",  # Missing docstring in magic method
+  "D107",  # Missing docstring in `__init__`
   "E501",  # line too long
 ]
 line-length = 100

--- a/tests/common.py
+++ b/tests/common.py
@@ -190,4 +190,6 @@ def sqlite_db_uri(db_uri="sqlite:///test.db"):
 def pg_db_uri(
     db_uri="postgresql://eralchemy:eralchemy@localhost:5432/eralchemy",
 ):
+    engine = create_engine(db_uri)
+    Base.metadata.create_all(engine)
     return db_uri

--- a/tests/test_intermediary_to_dot.py
+++ b/tests/test_intermediary_to_dot.py
@@ -33,6 +33,7 @@ column_inside = re.compile(
 
 def assert_is_dot_format(dot):
     """Checks that the dot is usable by graphviz."""
+
     # We launch a process calling graphviz to render the dot. If the exit code is not 0 we assume that the syntax
     # wasn't good
     def run_graph(dot):


### PR DESCRIPTION
This reverts commit d41759a96617c71cef8101a85a498b37cb6a8e12 - which disabled the pipeline.
Until we have the new pipeline up with nox - the existing tox pipeline should stay to have running tests :)

* This also fixes the broken ruff settings and switches to ruff only instead of black, while keeping the settings.
* add *.orig to the gitignore
* use ruff and ruff format in pre-commit instead of deprecated [prettier-pre-commit](https://github.com/pre-commit/mirrors-prettier)