### PR TITLE
build: create a release workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,28 @@
+name: Upload Python Package to PyPI
+
+on:
+  release:
+    types: [created]
+
+env:
+  FORCE_COLOR: "1" # Make tools pretty.
+  TWINE_USERNAME: __token__
+  TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+
+jobs:
+  tests:
+    uses: ./.github/workflows/unit.yaml
+
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: pip install wheel twine build
+      - name: build
+        run: python -m build
+      - name: publish
+        run: twine upload dist/*

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,35 @@
+# Release instructions
+
+This page contains the steps to make a release and some helpful resources to get you started.
+
+Create an issue and copy/paste the steps below to release a new version. Close the issue when it is done.
+
+These steps should be taken in order to create a new release![^release-refs]
+
+```md
+**Double check for quality-control**
+
+- [ ] There are no [open issues with a `impact: block-release` label](https://github.com/eralchemy/eralchemy/labels/block-release)
+
+**Prepare the codebase for a new version**
+
+- [ ] Bump `__version__` in [`pyproject.toml`](https://github.com/eralchemy/eralchemy/blob/main/pyproject.toml#L8)
+- [ ] Make a release commit: `git commit -m 'bump: 0.1.9 → 0.2.0'`
+- [ ] Push the RLS commit `git push upstream main`
+- [ ] If a **release candidate** is needed, tick this box when we're now ready for a full release.
+
+**Make the release**
+
+- [ ] [Start a new GitHub release](https://github.com/eralchemy/eralchemy/releases/new)
+  - Call the release the current version, e.g. `v0.2.0`
+  - In the **`Choose a Tag:`** dropdown, type in the release name (e.g., `v0.2.0`) and click "Create new tag"
+  - In the **`Target:`** dropdown, pin it to the release commit that you've just pushed.
+  - Generate the automatic release notes, eventually manually specify the previous version (useful when several release candidate have been made)
+- [ ] Confirm that the release completed
+  - [The `publish` github action job](https://github.com/eralchemy/eralchemy/blob/main/.github/workflows/publish.yaml) has completed successfully in the [actions tab](https://github.com/eralchemy/eralchemy/actions).
+  - [The PyPI version is updated](https://pypi.org/project/eralchemy/)
+- [ ] Hide the previous patch version build in the RDT interface if needed.
+- [ ] Celebrate, you're done!
+
+[^release-refs]: Taken from [the release checklist](https://github.com/eralchemy/eralchemy/blob/main/RELEASE.md). See [the release documentation](https://pydata-sphinx-theme.readthedocs.io/en/latest/contribute/policies.html#release-policy) for an overview of release processes.
+```


### PR DESCRIPTION
As I'm waiting for the tests to be restored, I decided to move forward with the release process. This PR contains a release.md file that should be used as a model when making a new release (it's a very nice checklist that I use myself for some time) and a github action to push things to pypi. 

> [!NOTE] 
> I already generated the pypi token and added it to the secrets variables