### PR TITLE
Fixup mermaid er cardinalities

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v5.0.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -10,7 +10,7 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
-        stages: [commit]
+        stages: [pre-commit]
         additional_dependencies:
           - tomli
 
@@ -18,12 +18,12 @@ repos:
     rev: v3.1.0
     hooks:
       - id: prettier
-        stages: [commit]
+        stages: [pre-commit]
         exclude: tests\/test_.+\.
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.4
+    rev: v0.7.4
     hooks:
       # Run the linter.
       - id: ruff

--- a/eralchemy/models.py
+++ b/eralchemy/models.py
@@ -204,12 +204,8 @@ class Relation(Drawable):
         return '{} "{}" -- "{}" {}'.format(*normalized)
 
     def to_mermaid_er(self) -> str:
-        left = Relation.cardinalities_crowfoot.get(
-            self.left_cardinality,
-        )
-        right = Relation.cardinalities_crowfoot.get(
-            self.right_cardinality,
-        )
+        left = Relation.cardinalities_crowfoot.get(self.left_cardinality, self.left_cardinality)
+        right = Relation.cardinalities_crowfoot.get(self.right_cardinality, self.right_cardinality)
 
         left_col = sanitize_mermaid(self.left_table, is_er=True)
         right_col = sanitize_mermaid(self.right_table, is_er=True)


### PR DESCRIPTION
The mermaid output from `eralchemy -i 'example/forum.er' -o output.md -m mermaid_er` was not renderable in mermaid, as the cardinalities did not fallback to the given ones in the fallback.

This is fixed. Additionally, the pre-commit config is updated