### PR TITLE
Add mermaid file export functionality

### DIFF
--- a/eralchemy/main.py
+++ b/eralchemy/main.py
@@ -145,6 +145,20 @@ title: {title}
         file_out.write(md_markup)
 
 
+def intermediary_to_mermaid_plain(tables, relationships, output, title=""):
+    """Saves the intermediary representation to markdown."""
+    markup = _intermediary_to_mermaid(tables, relationships)
+    if title:
+        markup = f"""---
+title: {title}
+---
+{markup}
+"""
+    md_markup = f"```mermaid\n\n{markup}\n\n```\n"
+    with open(output, "w") as file_out:
+        file_out.write(md_markup)
+
+
 def intermediary_to_dot(tables, relationships, output, title=""):
     """Save the intermediary representation to dot format."""
     dot_file = _intermediary_to_dot(tables, relationships, title)
@@ -222,6 +236,7 @@ switch_output_mode_auto = {
     "er": intermediary_to_markdown,
     "mermaid": intermediary_to_mermaid,
     "mermaid_er": intermediary_to_mermaid_er,
+    "mermaid_plain": intermediary_to_mermaid_plain,
     "graph": intermediary_to_schema,
     "dot": intermediary_to_dot,
 }

--- a/example/mermaid.py
+++ b/example/mermaid.py
@@ -1,0 +1,136 @@
+"""Forum like example.
+
+Code credits go to NewsMeme (https://github.com/danjac/newsmeme)
+"""
+
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Table,
+    Text,
+    Unicode,
+    UnicodeText,
+)
+from sqlalchemy.orm import Relationship, declarative_base
+
+Base = declarative_base()
+
+
+post_tags = Table(
+    "post_tags",
+    Base.metadata,
+    Column(
+        "post_id",
+        Integer,
+        ForeignKey("posts.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "tag_id",
+        Integer,
+        ForeignKey("tags.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+)
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    # user roles
+    MEMBER = 100
+    MODERATOR = 200
+    ADMIN = 300
+
+    id = Column(Integer, primary_key=True)
+    username = Column(Unicode(60), unique=True, nullable=False)
+    email = Column(String(150), unique=True, nullable=False)
+    karma = Column(Integer, default=0)
+    date_joined = Column(DateTime, default=datetime.utcnow)
+    activation_key = Column(String(80), unique=True)
+    role = Column(Integer, default=MEMBER)
+    receive_email = Column(Boolean, default=False)
+    email_alerts = Column(Boolean, default=False)
+    followers = Column(Text)
+    following = Column(Text)
+
+    _password = Column("password", String(80))
+    _openid = Column("openid", String(80), unique=True)
+
+
+class Post(Base):
+    __tablename__ = "posts"
+
+    PUBLIC = 100
+    FRIENDS = 200
+    PRIVATE = 300
+
+    PER_PAGE = 40
+
+    id = Column(Integer, primary_key=True)
+
+    author_id = Column(Integer, ForeignKey(User.id, ondelete="CASCADE"), nullable=False)
+
+    title = Column(Unicode(200))
+    description = Column(UnicodeText)
+    link = Column(String(250))
+    date_created = Column(DateTime, default=datetime.utcnow)
+    score = Column(Integer, default=1)
+    num_comments = Column(Integer, default=0)
+    votes = Column(Text)
+    access = Column(Integer, default=PUBLIC)
+
+    _tags = Column("tags", UnicodeText)
+
+    author = Relationship(User, innerjoin=True, lazy="joined")
+
+
+class Comment(Base):
+    __tablename__ = "comments"
+
+    PER_PAGE = 20
+
+    id = Column(Integer, primary_key=True)
+
+    author_id = Column(Integer, ForeignKey(User.id, ondelete="CASCADE"), nullable=False)
+
+    post_id = Column(Integer, ForeignKey(Post.id, ondelete="CASCADE"), nullable=False)
+
+    parent_id = Column(Integer, ForeignKey("comments.id", ondelete="CASCADE"))
+
+    comment = Column(UnicodeText)
+    date_created = Column(DateTime, default=datetime.utcnow)
+    score = Column(Integer, default=1)
+    votes = Column(Text)
+
+    author = Relationship(User, innerjoin=True, lazy="joined")
+
+    post = Relationship(Post, innerjoin=True, lazy="joined")
+
+    parent = Relationship("Comment", remote_side=[id])
+
+
+class Tag(Base):
+    __tablename__ = "tags"
+
+    id = Column(Integer, primary_key=True)
+    slug = Column(Unicode(80), unique=True)
+
+    _name = Column("name", Unicode(80), unique=True)
+
+
+if __name__ == "__main__":
+    from eralchemy import render_er
+
+    render_er(Base, "forum_mermaid.md", mode="mermaid")
+    render_er(Base, "forum_mermaid_er.md", mode="mermaid_er")
+    render_er(Base, "forum_mermaid_plain.md", mode="mermaid_plain")
+    render_er(
+        Base, "forum_mermaid_plain_with_title.md", mode="mermaid_plain", title="Forum ER Diagram"
+    )


### PR DESCRIPTION
Currently, the Mermaid diagrams are exported into a Markdown file as comments and rendered as images using the mermaid.ink link. 
I have now implemented a feature to export the Mermaid diagrams into a Markdown file with the `mode="mermaid_plain"` parameter.