### PR TITLE
allow calling format without writing to file

### DIFF
--- a/eralchemy/helpers.py
+++ b/eralchemy/helpers.py
@@ -22,8 +22,6 @@ def check_args(args: Namespace) -> None:
         return
     if args.i is None:
         fail("Cannot draw ER diagram of no database.")
-    if args.o is None:
-        fail("Cannot draw ER diagram with no output file.")
 
 
 def check_args_has_attributes(args: Namespace) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -124,7 +124,8 @@ def test_filter_exclude_columns(exclude_columns):
 
 
 def test_get_output_mode():
-    assert get_output_mode("hello.png", "auto") == intermediary_to_schema
+    # access .func for partial
+    assert get_output_mode("hello.png", "auto").func == intermediary_to_schema
     assert get_output_mode("hello.er", "auto") == intermediary_to_markdown
     assert get_output_mode("hello.dot", "auto") == intermediary_to_dot
     assert get_output_mode("hello.md", "auto") == intermediary_to_mermaid


### PR DESCRIPTION
This adds a stdout mode to eralchemy.

Example given:

`eralchemy -i example/forum.er -m mermaid`

render_er either requires a filename or a mode other than "auto".
For graphviz, this does not work yet until something like https://github.com/xflr6/graphviz/pull/234 is merged.
Pygraphviz works just fine with it.

Closes #148 