### PR TITLE
replace static constants with a config object

### DIFF
--- a/eralchemy/cst.py
+++ b/eralchemy/cst.py
@@ -1,23 +1,27 @@
 """All the constants used in the module."""
 
-TABLE = (
+DOT_TABLE = (
     '"{}" [label=<<FONT FACE="Helvetica"><TABLE BORDER="0" CELLBORDER="1"'
     ' CELLPADDING="4" CELLSPACING="0">{}{}</TABLE></FONT>>];'
 )
-
-START_CELL = '<TR><TD ALIGN="LEFT"><FONT>'
-FONT_TAGS = "<FONT>{}</FONT>"
+DOT_FONT_TAGS = "<FONT>{}</FONT>"
 # Used for each row in the table.
-ROW_TAGS = "<TR><TD{}>{}</TD></TR>"
-DOT_GRAPH_BEGINNING = """
-      graph {
-         graph [rankdir=LR];
-         node [label="\\N",
-             shape=plaintext
-         ];
-         edge [color=gray50,
-             minlen=2,
-             style=dashed
-         ];
-      """
-ER_FORMAT_TITLE = 'title {{label: "{}", size: "40"}}'
+DOT_ROW_TAGS = "<TR><TD{}>{}</TD></TR>"
+DOT_GRAPH_BEGINNING = """graph {
+    graph [rankdir=LR];
+    node [label="\\N",
+        shape=plaintext
+    ];
+    edge [color=gray50,
+        minlen=2,
+        style=dashed
+    ];"""
+MARKDOWN_TITLE = 'title {{label: "{}", size: "40"}}'
+
+config = {
+    "DOT_TABLE": DOT_TABLE,
+    "DOT_FONT_TAGS": DOT_FONT_TAGS,
+    "DOT_ROW_TAGS": DOT_ROW_TAGS,
+    "DOT_GRAPH_BEGINNING": DOT_GRAPH_BEGINNING,
+    "MARKDOWN_TITLE": MARKDOWN_TITLE,
+}

--- a/eralchemy/main.py
+++ b/eralchemy/main.py
@@ -12,7 +12,7 @@ from importlib.metadata import PackageNotFoundError, version
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.exc import ArgumentError
 
-from .cst import DOT_GRAPH_BEGINNING, ER_FORMAT_TITLE
+from .cst import config
 from .helpers import check_args
 from .parser import (
     ParsingException,
@@ -113,7 +113,8 @@ def intermediary_to_markdown(tables, relationships, title=""):
     """Saves the intermediary representation to markdown."""
     er_markup = _intermediary_to_markdown(tables, relationships)
     if title:
-        er_markup_with_config = f"{ER_FORMAT_TITLE.format(title)}\n{er_markup}"
+        format_title = config["MARKDOWN_TITLE"].format(title)
+        er_markup_with_config = f"{format_title}\n{er_markup}"
     else:
         er_markup_with_config = er_markup
     return er_markup_with_config
@@ -196,11 +197,11 @@ def _intermediary_to_dot(tables, relationships, title=""):
     r = "\n".join(r.to_dot() for r in relationships)
 
     graph_config = (
-        f"""{DOT_GRAPH_BEGINNING}
+        f"""{config["DOT_GRAPH_BEGINNING"]}
          label="{title}"
          labelloc=t\n"""
         if title
-        else DOT_GRAPH_BEGINNING
+        else config["DOT_GRAPH_BEGINNING"]
     )
     return f"{graph_config}\n{t}\n{r}\n}}"
 
@@ -420,4 +421,13 @@ def render_er(
 
 if __name__ == "__main__":
     # cli("-i example/forum.er -o test.dot".split(" "))
+    config["DOT_GRAPH_BEGINNING"] = """graph {
+    graph [rankdir=TD];
+    node [label="\\N",
+        shape=plaintext
+    ];
+    edge [color=gray50,
+        minlen=2,
+        style=dashed
+    ];"""
     cli()

--- a/eralchemy/models.py
+++ b/eralchemy/models.py
@@ -10,7 +10,7 @@ import re
 from abc import ABC, abstractmethod
 from typing import ClassVar
 
-from .cst import FONT_TAGS, ROW_TAGS, TABLE
+from .cst import config
 
 
 class Drawable(ABC):
@@ -112,7 +112,7 @@ class Column(Drawable):
         return f" {type_str} {name} {'PK' if self.is_key else ''}"
 
     def to_dot(self) -> str:
-        base = ROW_TAGS.format(
+        base = config["DOT_ROW_TAGS"].format(
             ' ALIGN="LEFT" {port}',
             "{key_opening}{col_name}{key_closing} {type}{null}",
         )
@@ -120,8 +120,10 @@ class Column(Drawable):
             port=f'PORT="{self.name}"' if self.name else "",
             key_opening="<u>" if self.is_key else "",
             key_closing="</u>" if self.is_key else "",
-            col_name=FONT_TAGS.format(self.name),
-            type=(FONT_TAGS.format(" [{}]").format(self.type) if self.type is not None else ""),
+            col_name=config["DOT_FONT_TAGS"].format(self.name),
+            type=(
+                config["DOT_FONT_TAGS"].format(f" [{self.type}]") if self.type is not None else ""
+            ),
             null=" NOT NULL" if not self.is_null else "",
         )
 
@@ -282,11 +284,11 @@ class Table(Drawable):
 
     @property
     def header_dot(self) -> str:
-        return ROW_TAGS.format("", f'<B><FONT POINT-SIZE="16">{self.name}</FONT></B>')
+        return config["DOT_ROW_TAGS"].format("", f'<B><FONT POINT-SIZE="16">{self.name}</FONT></B>')
 
     def to_dot(self) -> str:
         body = "".join(c.to_dot() for c in self.columns)
-        return TABLE.format(self.name, self.header_dot, body)
+        return config["DOT_TABLE"].format(self.name, self.header_dot, body)
 
     def __str__(self) -> str:
         return self.header_markdown

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,6 @@ ignore = [
   "D107",  # Missing docstring in `__init__`
   "E501",  # line too long
 ]
-ignore-init-module-imports = true
 
 [tool.ruff.lint.flake8-quotes]
 docstring-quotes = "double"


### PR DESCRIPTION
This makes configuration of templates much easier.

For example using:

```python
    config["DOT_GRAPH_BEGINNING"] = """
graph {
    graph [rankdir=TB];
    node [label="\\N",
        shape=plaintext
    ];
    edge [color=gray50,
        minlen=2,
        style=dashed
    ];
      """
    render_er(Base, "forum.svg")
```

we can configure the dot files to be top down instead of left right, which is desirable in some cases.

closes #136 
closes #63 