### PR TITLE
add support for plantuml

### DIFF
--- a/eralchemy/helpers.py
+++ b/eralchemy/helpers.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
 
+import base64
+import string
 import sys
 from argparse import Namespace
 from typing import Any
+from zlib import compress
+
+# from https://github.com/dougn/python-plantuml/blob/master/plantuml.py
+plantuml_alphabet = string.digits + string.ascii_uppercase + string.ascii_lowercase + "-_"
+base64_alphabet = string.ascii_uppercase + string.ascii_lowercase + string.digits + "+/"
+b64_to_plantuml = bytes.maketrans(
+    base64_alphabet.encode("utf-8"), plantuml_alphabet.encode("utf-8")
+)
 
 
 # from https://github.com/mitsuhiko/flask/blob/master/scripts/make-release.py L92
@@ -37,3 +47,10 @@ def check_args_has_attributes(args: Namespace) -> None:
 def check_args_has_attribute(args: Namespace, name: str) -> None:
     if not hasattr(args, name):
         raise Exception(f"{name} should be set")
+
+
+def plantuml_convert(puml_markup):
+    zlibbed_str = compress(puml_markup.encode("utf-8"))
+    compressed_string = zlibbed_str[2:-4]
+    markup_encoded = base64.b64encode(compressed_string).translate(b64_to_plantuml).decode("utf-8")
+    return markup_encoded

--- a/eralchemy/models.py
+++ b/eralchemy/models.py
@@ -26,6 +26,10 @@ class Drawable(ABC):
         """Transforms the intermediary object to its syntax in the dot format."""
         raise NotImplementedError()
 
+    def to_puml(self) -> str:
+        """Transforms the intermediary object to it's syntax in the PlantUML format."""
+        raise NotImplementedError()
+
     def __eq__(self, other) -> bool:
         return self.__dict__ == other.__dict__
 
@@ -123,6 +127,15 @@ class Column(Drawable):
             col_name=FONT_TAGS.format(self.name),
             type=(FONT_TAGS.format(" [{}]").format(self.type) if self.type is not None else ""),
             null=" NOT NULL" if not self.is_null else "",
+        )
+
+    def to_puml(self) -> str:
+        return " {} {} : {}{}{}".format(
+            self.key_symbol,
+            self.name,
+            self.type.replace("(", "<").replace(")", ">"),
+            " NOT NULL" if not self.is_null else "",
+            "\n--" if self.is_key else "",
         )
 
 
@@ -230,6 +243,31 @@ class Relation(Drawable):
             f'"{self.left_table}"{left_col} -- "{self.right_table}"{right_col} [{",".join(cards)}];'
         )
 
+    def to_puml(self) -> str:
+        __puml_left_cardinalities = {
+            "*": "}o",
+            "?": "|o",
+            "+": "}1",
+            "1": "||",
+            "": None,
+        }
+        __puml_right_cardinalities = {
+            "*": "o{",
+            "?": "o|",
+            "+": "1{",
+            "1": "||",
+            "": None,
+        }
+        left_col = f"::{self.left_column}" if self.left_column else ""
+        right_col = f"::{self.right_column}" if self.right_column else ""
+
+        return (
+            f"{self.left_table}{left_col}"
+            f" {__puml_left_cardinalities[self.left_cardinality]}"
+            f"--{__puml_right_cardinalities[self.right_cardinality]}"
+            f" {self.right_table}{right_col}"
+        )
+
     def __eq__(self, other: object) -> bool:
         if super().__eq__(other):
             return True
@@ -287,6 +325,11 @@ class Table(Drawable):
     def to_dot(self) -> str:
         body = "".join(c.to_dot() for c in self.columns)
         return TABLE.format(self.name, self.header_dot, body)
+
+    def to_puml(self) -> str:
+        columns = [c.to_puml() for c in self.columns]
+        name = sanitize_mermaid(self.name)
+        return f"entity  {name}{{\n" + "\n  ".join(columns) + "\n}"
 
     def __str__(self) -> str:
         return self.header_markdown

--- a/example/simple.py
+++ b/example/simple.py
@@ -22,8 +22,9 @@ class Child(Base):
 def example():
     render_er(Base, "simple.png")
     render_er(Base, "simple.dot")
-    render_er(Base, "simple.pdf")
+    # render_er(Base, "simple.pdf")
     render_er(Base, "simple.er")
+    render_er(Base, "simple.puml")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
adds support for plantuml rendering

supersedes #142 

example: `eralchemy -i example/forum.er -o test.puml`

Does not require a deprecated dependency and works quite well with the rendered version on plantuml.com