### PR TITLE
Add column sort mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: v5.0.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ render_er(Base, "forum.svg")
 graph LR
     subgraph Inputs
         A[Markdown representation]
-        )B[SQLAlchemy Schema]
+        B[SQLAlchemy Schema]
         C[Existing database]
         D[Other ORM ?]
     end
@@ -151,7 +151,7 @@ Every feedback is welcome on the [GitHub issues](https://github.com/eralchemy/er
 
 Install the development dependencies using
 
-    $ pip install -e .[ci,dev]
+    $ pip install -e .[dev,test]
 
 Make sure to run the pre-commit to fix formatting
 
@@ -162,7 +162,7 @@ All tested PR are welcome.
 ## Running tests
 
 This project uses the pytest test suite.
-To run the tests, use : `$ pytest` or `$ tox`.
+To run the tests, use : `$ pytest` or `$ nox`.
 
 Some tests require having a local PostgreSQL database with a schema named test in a database
 named test all owned by a user named eralchemy with a password of eralchemy.

--- a/eralchemy/helpers.py
+++ b/eralchemy/helpers.py
@@ -4,8 +4,11 @@ import base64
 import string
 import sys
 from argparse import Namespace
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from zlib import compress
+
+if TYPE_CHECKING:
+    from .models import Column
 
 # from https://github.com/dougn/python-plantuml/blob/master/plantuml.py
 plantuml_alphabet = string.digits + string.ascii_uppercase + string.ascii_lowercase + "-_"
@@ -54,3 +57,20 @@ def plantuml_convert(puml_markup):
     compressed_string = zlibbed_str[2:-4]
     markup_encoded = base64.b64encode(compressed_string).translate(b64_to_plantuml).decode("utf-8")
     return markup_encoded
+
+
+def original_order_keys_first(column: Column) -> bool:
+    """Function can be used with sorted() and places columns with primary keys first.
+
+    All other non-key columns will stay in the same order as they were in the original list.
+
+    Example: Given is the following list of `Column` objects with names and is_key attributes:
+    `"D", "C", "B", "A", "E"` where `D` and `A` are key columns.
+    `False, True, True, False, True` is the result of element-wise application of this function.
+    `"D", "A", "C", "B", "E"` is the result of `sorted(input, key=original_order_keys_first)`,
+        because elements with `False` are sorted first.
+
+    :param column: Column object to sort
+    :return: Boolean indicating if the column is not a key column
+    """
+    return not column.is_key

--- a/eralchemy/main.py
+++ b/eralchemy/main.py
@@ -56,7 +56,6 @@ def cli(args=None) -> None:
     if args.v:
         print(f"eralchemy version {__version__}.")
         exit(0)
-    print("#", args.sort_mode)
     output = render_er(
         args.i,
         args.o,
@@ -110,7 +109,6 @@ def get_argparser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--sort_mode",
         nargs="?",
-        default="alphabetical",
         choices=["alphabetical", "original"],
         help="sorting mode for the key columns and then the non-key columns, default: alphabetical",
     )

--- a/eralchemy/sqla.py
+++ b/eralchemy/sqla.py
@@ -84,10 +84,9 @@ def column_to_intermediary(
 
 def table_to_intermediary(table: sa.Table) -> Table:
     """Transform an SQLAlchemy Table object to its intermediary representation."""
-    table_columns = getattr(table.c, "_colset", getattr(table.c, "_data", {}).values())
     return Table(
         name=table.fullname,
-        columns=[column_to_intermediary(col) for col in table_columns],
+        columns=[column_to_intermediary(col) for col in table.columns],
     )
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,6 @@
 import pytest
+from sqlalchemy import Column, String
+from sqlalchemy.orm import declarative_base
 
 from eralchemy.main import (
     all_to_intermediary,
@@ -142,3 +144,76 @@ def test_get_output_mode():
 
 def test_import_render_er():
     from eralchemy import render_er  # noqa: F401
+
+
+@pytest.mark.parametrize(
+    "sort_mode, expected_column_order",
+    (
+        pytest.param(
+            None,
+            [
+                # key columns in alphabetical order first
+                "fifth_column",
+                "first_column",
+                # then non-key columns in alphabetical order
+                "fourth_column",
+                "second_column",
+                "third_column",
+            ],
+            id="sort_mode=None",
+        ),
+        pytest.param(
+            "alphabetical",
+            [
+                # key columns in alphabetical order first
+                "fifth_column",
+                "first_column",
+                # then non-key columns in alphabetical order
+                "fourth_column",
+                "second_column",
+                "third_column",
+            ],
+            id="sort_mode='alphabetical'",
+        ),
+        pytest.param(
+            "original",
+            [
+                # key columns in original order first
+                "first_column",
+                "fifth_column",
+                # then non-key columns in original order
+                "second_column",
+                "third_column",
+                "fourth_column",
+            ],
+            id="sort_mode='original'",
+        ),
+    ),
+)
+def test_sort_mode(sort_mode, expected_column_order):
+    Base = declarative_base()
+
+    class Table(Base):
+        __tablename__ = "table"
+        first_column = Column(String, primary_key=True)
+        second_column = Column(String)
+        third_column = Column(String)
+        fourth_column = Column(String)
+        fifth_column = Column(String, primary_key=True)
+
+    tables, relationships = all_to_intermediary(Base)
+    actual_tables, actual_relationships = filter_resources(
+        tables,
+        relationships,
+        sort_mode=sort_mode,
+    )
+
+    # key columns first in alphabetical order, then non-key columns in alphabetical order
+
+    assert len(actual_tables) == 1
+    actual_table = actual_tables[0]
+    assert len(actual_table.columns) == len(expected_column_order)
+
+    # The order of columns in `table` and `expected_column_order` should be the same.
+    for column_index in range(len(actual_table.columns)):
+        assert actual_table.columns[column_index].name == expected_column_order[column_index]

--- a/tests/test_sqla_to_intermediary.py
+++ b/tests/test_sqla_to_intermediary.py
@@ -85,6 +85,7 @@ def test_database_to_intermediary_with_schema(pg_db_uri):
 
 
 @pytest.mark.external_db
+@pytest.mark.filterwarnings("ignore:Ignoring duplicate class name")
 def test_database_to_intermediary_with_multiple_schemas(pg_db_uri):
     tables, relationships = database_to_intermediary(
         pg_db_uri,

--- a/tests/test_sqla_to_intermediary.py
+++ b/tests/test_sqla_to_intermediary.py
@@ -55,8 +55,9 @@ def table_equals_helper(sqla_table, expected_table):
     table = table_to_intermediary(sqla_table.__table__)
     assert len(table.columns) == len(expected_table.columns)
     assert table.name == expected_table.name
-    for col in table.columns:
-        assert col in expected_table.columns
+    # The order of columns in `table` and `expected_table` should be the same.
+    for column_index in range(len(expected_table.columns)):
+        assert table.columns[column_index] == expected_table.columns[column_index]
 
 
 def test_tables():


### PR DESCRIPTION
Adds argument `sort_mode` with two modes `alphabetical` (default) and `original`.
* `alphabetical`: table has key columns in alphabetical order first, then non-key columns in alphabetical order
* `original`: table has key columns in original order first, then non-key columns in original order

Closes #153 

---
Furthermore, this PR fixes:

* **fix: use python 3.8 compatible pre-commit hooks**  
Version 6.0.0 of `https://github.com/pre-commit/pre-commit-hooks` in pre-commit config is only compatible with Python >=3.9. For Python 3.8, version 5.0.0 would be required. Therefore, I have downgraded it to 5.0.0 again. Or should Python 3.8 support dropped overall at some point?

* **docs: improve outdated information**
  * README describes to install the `ci` extra option, which does not exist anymore: `pip install -e .[ci,dev]`.
I guess changing it to `pip install -e .[dev,test]` would have the same effect.  
  * architecture mermaid diagram in README has a syntax error -> fixed it
  * README mentions `tox` for testing, which was removed last year from the repo (2c19348). Replaced it with `nox` in the README.

* **test: silence sqla warning, when having same table names in multiple schemas**  
`tests/test_sqla_to_intermediary.py::test_database_to_intermediary_with_multiple_schemas` produced warnings, because it maps tables from multiple schemas to the same ORM class. Instead of suppressing the warning, there is also an option to resolve this warning sustainably, if favored. But I would prefer to adress this in another issue.

I have added these fixes to the PR, but they are just proposals. Let me know, if I should revert some of the changes again.